### PR TITLE
PT-3948 Documentación - Añadir tarjeta de prueba Amex

### DIFF
--- a/docs/Tarjetas-de-prueba.md
+++ b/docs/Tarjetas-de-prueba.md
@@ -50,7 +50,7 @@ Mastercard | 5180300000000039 | Rechaza **3DS-N**
 Mastercard | 5180300000000047 | Deja la transacción en estado pendiente y se resuelve a aprobado **3DS-C**
 Mastercard | 5180300000000054 | Deja la transacción en estado pendiente y se resuelve a rechazado **3DS-A**
 Mastercard | 5292594382060745 | Aprueba **3DS-C**
-American Express | 376651001281274 | Aprueba si se proporciona la expiración 06/22 y el cvv 4637 de lo contrario rechaza
+American Express | 376651001281274 | Aprueba si se proporciona la expiración 06/36 y el cvv 4637 de lo contrario rechaza
 Discover | 6550590000000001 | Aprueba
 Discover | 6550590000000019 | Rechaza
 Discover | 6550590000000027 | Deja la transacción en estado pendiente y se resuelve a aprobado


### PR DESCRIPTION
Se cambia la fecha de expiración de la tarjeta de American Express `376651001281274` de `06/22` a `06/36` dado que ese es el caso actual para probar

[Preview](https://alejandroab.stoplight.io/docs/api-services-docs/bbf00416b9c62-numeros-de-tarjeta-de-pruebas)